### PR TITLE
Moving pollen-log to it's own database.

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -4,6 +4,7 @@
 # Local state files
 *.tfstate
 *.tfstate.backup
+*.tfstate.*.backup
 
 # Local variable files (contains private Project IDs/secrets)
 *.tfvars

--- a/infra/firestore.tf
+++ b/infra/firestore.tf
@@ -1,10 +1,20 @@
 # Create the Firestore Database (Native Mode)
-resource "google_firestore_database" "database" {
+resource "google_firestore_database" "weather_database" {
   # Depends on the API being enabled (managed in main.tf)
   depends_on = [google_project_service.firestore]
 
   project     = var.project_id
   name        = "weather-log"
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+}
+
+resource "google_firestore_database" "pollen_database" {
+  # Depends on the API being enabled (managed in main.tf)
+  depends_on = [google_project_service.firestore]
+
+  project     = var.project_id
+  name        = "pollen-log"
   location_id = var.region
   type        = "FIRESTORE_NATIVE"
 }

--- a/services/pollen-collector/main.go
+++ b/services/pollen-collector/main.go
@@ -85,9 +85,9 @@ type PollenSnapshot struct {
 }
 
 type PollenCacheDoc struct {
-	LastUpdated time.Time        `firestore:"last_updated"`
-	CurrentValue PollenSnapshot  `firestore:"current"`
-	History     []PollenSnapshot `firestore:"history"`
+	LastUpdated  time.Time        `firestore:"last_updated"`
+	CurrentValue PollenSnapshot   `firestore:"current"`
+	History      []PollenSnapshot `firestore:"history"`
 }
 
 // nonRetryable wraps errors that should not be retried (e.g. 401, 403, bad JSON).
@@ -250,7 +250,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	client, err := firestore.NewClientWithDatabase(ctx, projectID, shared.DatabaseID)
+	client, err := firestore.NewClientWithDatabase(ctx, projectID, shared.PollenDatabaseID)
 	if err != nil {
 		slog.Error("Failed to create firestore client", "error", err)
 		os.Exit(1)

--- a/services/pollen-provider/internal/repository/firestore.go
+++ b/services/pollen-provider/internal/repository/firestore.go
@@ -27,11 +27,11 @@ type StoredPollenPlant struct {
 }
 
 type PollenSnapshot struct {
-	LocationID      string             `firestore:"location_id"`
-	CollectedAt     time.Time          `firestore:"collected_at"`
-	OverallIndex    int                `firestore:"overall_index"`
-	OverallCategory string             `firestore:"overall_category"`
-	DominantType    string             `firestore:"dominant_type"`
+	LocationID      string              `firestore:"location_id"`
+	CollectedAt     time.Time           `firestore:"collected_at"`
+	OverallIndex    int                 `firestore:"overall_index"`
+	OverallCategory string              `firestore:"overall_category"`
+	DominantType    string              `firestore:"dominant_type"`
 	Types           []StoredPollenType  `firestore:"types"`
 	Plants          []StoredPollenPlant `firestore:"plants"`
 }
@@ -47,7 +47,7 @@ type FirestoreRepository struct {
 }
 
 func NewFirestoreRepository(ctx context.Context, projectID string) (*FirestoreRepository, error) {
-	client, err := firestore.NewClientWithDatabase(ctx, projectID, shared.DatabaseID)
+	client, err := firestore.NewClientWithDatabase(ctx, projectID, shared.PollenDatabaseID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/shared/constants.go
+++ b/services/shared/constants.go
@@ -1,7 +1,7 @@
 package shared
 
 const (
-	// DatabaseID is the Firestore database used by all services.
+	// Firestore databases used by each service.
 	WeatherDatabaseID = "weather-log"
 	PollenDatabaseID  = "pollen-log"
 

--- a/services/shared/constants.go
+++ b/services/shared/constants.go
@@ -2,11 +2,12 @@ package shared
 
 const (
 	// DatabaseID is the Firestore database used by all services.
-	DatabaseID = "weather-log"
+	WeatherDatabaseID = "weather-log"
+	PollenDatabaseID  = "pollen-log"
 
 	// Cache collection names shared between each collector/provider pair.
 	WeatherCacheCollection = "weather_cache"
-  WeatherRawCollection   = "weather_raw"
+	WeatherRawCollection   = "weather_raw"
 	PollenCacheCollection  = "pollen_cache"
 	PollenRawCollection    = "pollen_raw"
 )

--- a/services/shared/constants_test.go
+++ b/services/shared/constants_test.go
@@ -2,9 +2,15 @@ package shared
 
 import "testing"
 
-func TestDatabaseID(t *testing.T) {
-	if DatabaseID != "weather-log" {
-		t.Errorf("DatabaseID = %q, want %q", DatabaseID, "weather-log")
+func TestWeatherDatabaseID(t *testing.T) {
+	if WeatherDatabaseID != "weather-log" {
+		t.Errorf("WeatherDatabaseID = %q, want %q", WeatherDatabaseID, "weather-log")
+	}
+}
+
+func TestPollenDatabaseID(t *testing.T) {
+	if PollenDatabaseID != "pollen-log" {
+		t.Errorf("PollenDatabaseID = %q, want %q", PollenDatabaseID, "pollen-log")
 	}
 }
 
@@ -17,6 +23,12 @@ func TestWeatherCacheCollection(t *testing.T) {
 func TestPollenCacheCollection(t *testing.T) {
 	if PollenCacheCollection != "pollen_cache" {
 		t.Errorf("PollenCacheCollection = %q, want %q", PollenCacheCollection, "pollen_cache")
+	}
+}
+
+func TestDatabaseIDsAreDistinct(t *testing.T) {
+	if WeatherDatabaseID == PollenDatabaseID {
+		t.Error("WeatherDatabaseID and PollenDatabaseID must be distinct")
 	}
 }
 

--- a/services/weather-collector/main.go
+++ b/services/weather-collector/main.go
@@ -139,7 +139,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	client, err := firestore.NewClientWithDatabase(ctx, projectID, shared.DatabaseID)
+	client, err := firestore.NewClientWithDatabase(ctx, projectID, shared.WeatherDatabaseID)
 	if err != nil {
 		slog.Error("Failed to create firestore client", "error", err)
 		os.Exit(1)

--- a/services/weather-provider/internal/repository/firestore.go
+++ b/services/weather-provider/internal/repository/firestore.go
@@ -55,7 +55,7 @@ type FirestoreRepository struct {
 }
 
 func NewFirestoreRepository(ctx context.Context, projectID string) (*FirestoreRepository, error) {
-	client, err := firestore.NewClientWithDatabase(ctx, projectID, shared.DatabaseID)
+	client, err := firestore.NewClientWithDatabase(ctx, projectID, shared.WeatherDatabaseID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
closes #36 

Had to run `terraform state mv google_firestore_database.database google_firestore_database.weather_database` before changing which database pollen collector and pollen provider is pointing to.