### PR TITLE
test: build break for deploy notifications v3 (#33)

### DIFF
--- a/services/shared/constants.go
+++ b/services/shared/constants.go
@@ -2,6 +2,9 @@ package shared
 
 import "time"
 
+// Intentional build break to test deploy failure notifications (issue #33, v3)
+var BuildBreaker = undefinedVariable
+
 const (
 	// Firestore databases used by each service.
 	WeatherDatabaseID = "weather-log"


### PR DESCRIPTION
## Summary
- Re-introduces intentional compile error in `services/shared/constants.go` to test Slack workflow failure notifications
- Now subscribed to `workflows:{event:"push"}` in Slack

## Test plan
- [ ] Merge to main
- [ ] Verify GitHub Actions deploy workflows fail
- [ ] Confirm Slack notification is received for the failure
- [ ] Revert the change on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)