### PR TITLE
Add view navigation to CLI dashboard for issue #60.

### DIFF
--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -38,7 +38,31 @@ Or with flags via `go run`:
 go run ./cmd -url=http://api-staging.ianbeefang.com -refresh=30s
 ```
 
-Enable debug logging with `DEBUG=true`. Quit the TUI with `q` or `Ctrl+C`.
+Enable debug logging with `DEBUG=true`.
+
+## Flags
+
+| Flag        | Env var             | Default                  | Description                                                            |
+|-------------|---------------------|--------------------------|------------------------------------------------------------------------|
+| `-url`      | `DASHBOARD_API_URL` | `http://localhost:8080`  | Dashboard API base URL.                                                |
+| `-refresh`  | `REFRESH_INTERVAL`  | `300s`                   | How often to refresh data in the background.                           |
+| `-location` | —                   | (unset)                  | Boot the CLI focused on a single location ID; arrows still navigate.   |
+
+If `-location` references an ID that the API doesn't return, the CLI shows a transient "location not found" message and falls back to the all-locations view.
+
+## Keys
+
+| Key            | Action                                                           |
+|----------------|------------------------------------------------------------------|
+| `←` / `→`      | Cycle through individual locations (wraps at the ends).          |
+| `↑`            | Return to the all-locations view.                                |
+| `r`            | Refresh now: full dashboard in all-view, focused location in single-view. |
+| `q` / `Ctrl+C` | Quit.                                                            |
+
+## API endpoints used
+
+- `GET /v1/dashboard` — full payload for every location. Used on startup and on each background refresh tick.
+- `GET /v1/dashboard/{locationID}` — single-location payload, same response shape with single-entry maps. Used when pressing `r` while focused on a single location.
 
 ## Build
 

--- a/clients/cli/cmd/main.go
+++ b/clients/cli/cmd/main.go
@@ -38,10 +38,11 @@ func main() {
 
 	urlFlag := flag.String("url", urlDefault, "Dashboard API base URL (env: DASHBOARD_API_URL)")
 	refreshFlag := flag.Duration("refresh", refreshDefault, "Refresh interval (env: REFRESH_INTERVAL)")
+	locationFlag := flag.String("location", "", "Initial location ID to focus on (arrows still navigate)")
 	flag.Parse()
 
 	initLogging()
-	slog.Info(appName+" starting", "url", *urlFlag, "refresh", refreshFlag.String())
+	slog.Info(appName+" starting", "url", *urlFlag, "refresh", refreshFlag.String(), "initial_location", *locationFlag)
 
 	apiClient, err := client.New(*urlFlag)
 	if err != nil {
@@ -49,7 +50,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	m := tui.NewModel(apiClient, *refreshFlag)
+	m := tui.NewModel(apiClient, *refreshFlag, *locationFlag)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		slog.Error(appName+" exited with error", "err", err)

--- a/clients/cli/internal/client/dashboard.go
+++ b/clients/cli/internal/client/dashboard.go
@@ -11,6 +11,17 @@ import (
 	"time"
 )
 
+// DefaultTimeout is applied to a request when the caller's context carries
+// no deadline of its own. Callers who need a different per-request limit
+// can pass their own context (via context.WithTimeout / WithDeadline) and
+// it will take precedence — fetch() only adds the default when the
+// incoming context is unbounded.
+//
+// We deliberately do not also set http.Client.Timeout: that is a hard
+// ceiling rather than a default, and it would silently override any
+// per-request value larger than itself, defeating the override semantics.
+const DefaultTimeout = 10 * time.Second
+
 // Client fetches the aggregated dashboard payload from dashboard-api.
 type Client struct {
 	baseURL string
@@ -33,33 +44,55 @@ func New(baseURL string) (*Client, error) {
 	}
 	return &Client{
 		baseURL: strings.TrimRight(baseURL, "/"),
-		http:    &http.Client{Timeout: 10 * time.Second},
+		http:    &http.Client{},
 	}, nil
 }
 
 // Fetch calls GET {baseURL}/v1/dashboard and parses the JSON response.
 func (c *Client) Fetch(ctx context.Context) (*Response, error) {
-	url := c.baseURL + "/v1/dashboard"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	return c.fetch(ctx, "/v1/dashboard", "fetch dashboard")
+}
+
+// FetchLocation calls GET {baseURL}/v1/dashboard/{locationID} and parses the
+// JSON response. The response shape matches Fetch(): three maps each
+// containing a single entry keyed by locationID.
+func (c *Client) FetchLocation(ctx context.Context, locationID string) (*Response, error) {
+	if locationID == "" {
+		return nil, fmt.Errorf("fetch location: empty locationID")
+	}
+	path := "/v1/dashboard/" + url.PathEscape(locationID)
+	return c.fetch(ctx, path, "fetch location")
+}
+
+func (c *Client) fetch(ctx context.Context, path, errLabel string) (*Response, error) {
+	// Apply the default timeout only when the caller hasn't supplied one;
+	// any caller-provided deadline takes precedence and is left untouched.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, DefaultTimeout)
+		defer cancel()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("fetch dashboard: build request: %w", err)
+		return nil, fmt.Errorf("%s: build request: %w", errLabel, err)
 	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetch dashboard: %w", err)
+		return nil, fmt.Errorf("%s: %w", errLabel, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return nil, fmt.Errorf("fetch dashboard: unexpected status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("%s: unexpected status %d: %s", errLabel, resp.StatusCode, string(body))
 	}
 
 	var out Response
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return nil, fmt.Errorf("fetch dashboard: decode: %w", err)
+		return nil, fmt.Errorf("%s: decode: %w", errLabel, err)
 	}
 	return &out, nil
 }

--- a/clients/cli/internal/client/dashboard_test.go
+++ b/clients/cli/internal/client/dashboard_test.go
@@ -135,3 +135,239 @@ func TestClientFetch_ErrorStatus(t *testing.T) {
 		t.Fatal("expected error on 500, got nil")
 	}
 }
+
+const sampleSingleLocationPayload = `{
+  "weather": {
+    "house-nick": {
+      "locationId": "house-nick",
+      "lastUpdated": "2026-04-13T14:30:05Z",
+      "tempC": 29.6,
+      "tempF": 85.2,
+      "humidityPercent": 62,
+      "pressureMb": 1013.25
+    }
+  },
+  "pressure": {
+    "house-nick": {
+      "locationId": "house-nick",
+      "lastUpdated": "2026-04-13T14:30:05Z",
+      "delta1h": 0.3,
+      "trend": "rising"
+    }
+  },
+  "pollen": {
+    "house-nick": {
+      "locationId": "house-nick",
+      "collectedAt": "2026-04-13T06:00:00Z",
+      "overallIndex": 4,
+      "overallCategory": "High",
+      "dominantType": "TREE"
+    }
+  }
+}`
+
+func TestClientFetchLocation_HappyPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sampleSingleLocationPayload))
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	resp, err := c.FetchLocation(context.Background(), "house-nick")
+	if err != nil {
+		t.Fatalf("FetchLocation: %v", err)
+	}
+
+	if gotPath != "/v1/dashboard/house-nick" {
+		t.Errorf("path = %q, want /v1/dashboard/house-nick", gotPath)
+	}
+
+	if w, ok := resp.Weather["house-nick"]; !ok {
+		t.Fatal("weather[house-nick] missing")
+	} else if w.TempF != 85.2 {
+		t.Errorf("TempF = %v, want 85.2", w.TempF)
+	}
+	if _, ok := resp.Pressure["house-nick"]; !ok {
+		t.Error("pressure[house-nick] missing")
+	}
+	if _, ok := resp.Pollen["house-nick"]; !ok {
+		t.Error("pollen[house-nick] missing")
+	}
+}
+
+func TestClientFetchLocation_PathEscapes(t *testing.T) {
+	var gotURI string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// RequestURI is the raw URI as sent on the wire — URL.Path would
+		// already be decoded, masking whether escaping happened.
+		gotURI = r.RequestURI
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New(srv.URL)
+	if _, err := c.FetchLocation(context.Background(), "weird id/with spaces"); err != nil {
+		t.Fatalf("FetchLocation: %v", err)
+	}
+	if gotURI != "/v1/dashboard/weird%20id%2Fwith%20spaces" {
+		t.Errorf("RequestURI = %q, want escaped form", gotURI)
+	}
+}
+
+func TestClientFetchLocation_EmptyID(t *testing.T) {
+	c, _ := New("http://localhost:9999")
+	if _, err := c.FetchLocation(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty locationID, got nil")
+	}
+}
+
+func TestResponseMerge_LWW_NewerSrcWins(t *testing.T) {
+	const olderTS = "2026-04-13T13:00:00Z"
+	const newerTS = "2026-04-13T14:30:05Z"
+	const olderPollenTS = "2026-04-12T06:00:00Z"
+
+	dst := &Response{
+		Weather: map[string]Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: olderTS, TempF: 70.0},
+			"house-nita": {LocationID: "house-nita", LastUpdated: olderTS, TempF: 71.0},
+		},
+		Pressure: map[string]Pressure{
+			"house-nick": {LocationID: "house-nick", LastUpdated: olderTS, Trend: "steady"},
+		},
+		Pollen: map[string]Pollen{
+			"house-nita": {LocationID: "house-nita", CollectedAt: olderPollenTS, OverallIndex: 1},
+		},
+	}
+	src := &Response{
+		Weather: map[string]Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: newerTS, TempF: 85.2}, // newer → overwrite
+		},
+		Pressure: map[string]Pressure{
+			"house-nick": {LocationID: "house-nick", LastUpdated: newerTS, Trend: "rising"}, // newer → overwrite
+		},
+		// pollen empty in src — house-nita's pollen should remain
+	}
+
+	dst.Merge(src)
+
+	if got := dst.Weather["house-nick"].TempF; got != 85.2 {
+		t.Errorf("Weather[house-nick].TempF = %v, want overwritten 85.2", got)
+	}
+	if got := dst.Weather["house-nita"].TempF; got != 71.0 {
+		t.Errorf("Weather[house-nita].TempF = %v, want preserved 71.0", got)
+	}
+	if got := dst.Pressure["house-nick"].Trend; got != "rising" {
+		t.Errorf("Pressure[house-nick].Trend = %q, want overwritten 'rising'", got)
+	}
+	if _, ok := dst.Pollen["house-nita"]; !ok {
+		t.Error("Pollen[house-nita] should be preserved when src has no pollen")
+	}
+}
+
+// TestResponseMerge_LWW_OlderSrcLoses locks in the load-bearing property:
+// a stale single-location response that arrives after a fresher full
+// response must NOT clobber the fresher data. This is the M1 race-window
+// fix from the issue-60 review.
+func TestResponseMerge_LWW_OlderSrcLoses(t *testing.T) {
+	const freshTS = "2026-04-13T14:30:05Z"
+	const staleTS = "2026-04-13T13:00:00Z"
+	const freshPollenTS = "2026-04-13T06:00:00Z"
+	const stalePollenTS = "2026-04-12T06:00:00Z"
+
+	dst := &Response{
+		Weather: map[string]Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: freshTS, TempF: 85.2},
+		},
+		Pressure: map[string]Pressure{
+			"house-nick": {LocationID: "house-nick", LastUpdated: freshTS, Trend: "rising"},
+		},
+		Pollen: map[string]Pollen{
+			"house-nick": {LocationID: "house-nick", CollectedAt: freshPollenTS, OverallIndex: 4},
+		},
+	}
+	stale := &Response{
+		Weather: map[string]Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: staleTS, TempF: 70.0},
+		},
+		Pressure: map[string]Pressure{
+			"house-nick": {LocationID: "house-nick", LastUpdated: staleTS, Trend: "steady"},
+		},
+		Pollen: map[string]Pollen{
+			"house-nick": {LocationID: "house-nick", CollectedAt: stalePollenTS, OverallIndex: 1},
+		},
+	}
+
+	dst.Merge(stale)
+
+	if got := dst.Weather["house-nick"].TempF; got != 85.2 {
+		t.Errorf("Weather[house-nick].TempF = %v, want preserved 85.2 (stale src must not overwrite)", got)
+	}
+	if got := dst.Pressure["house-nick"].Trend; got != "rising" {
+		t.Errorf("Pressure[house-nick].Trend = %q, want preserved 'rising'", got)
+	}
+	if got := dst.Pollen["house-nick"].OverallIndex; got != 4 {
+		t.Errorf("Pollen[house-nick].OverallIndex = %v, want preserved 4", got)
+	}
+}
+
+// TestResponseMerge_LWW_EqualTimestampSkips covers the steady-state case
+// today: weather upstream updates hourly, so two fetches in the same hour
+// return identical timestamps. Equal-timestamp merges should be no-ops
+// (we use > rather than >=) — keeps the property "merge is idempotent
+// for byte-equal inputs."
+func TestResponseMerge_LWW_EqualTimestampSkips(t *testing.T) {
+	const ts = "2026-04-13T14:30:05Z"
+	dst := &Response{
+		Weather: map[string]Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: ts, TempF: 85.2},
+		},
+	}
+	src := &Response{
+		Weather: map[string]Weather{
+			// Same timestamp, different value (shouldn't happen in practice,
+			// but proves the equal-timestamp branch).
+			"house-nick": {LocationID: "house-nick", LastUpdated: ts, TempF: 99.0},
+		},
+	}
+	dst.Merge(src)
+	if got := dst.Weather["house-nick"].TempF; got != 85.2 {
+		t.Errorf("Weather[house-nick].TempF = %v, want preserved 85.2 on equal timestamps", got)
+	}
+}
+
+func TestResponseMerge_NilGuards(t *testing.T) {
+	// nil receiver is a no-op (would crash otherwise).
+	var nilDst *Response
+	nilDst.Merge(&Response{})
+
+	// nil src is a no-op.
+	dst := &Response{Weather: map[string]Weather{"x": {TempF: 1}}}
+	dst.Merge(nil)
+	if dst.Weather["x"].TempF != 1 {
+		t.Error("Merge(nil) mutated dst")
+	}
+
+	// nil maps in dst should be initialised by Merge before writing.
+	empty := &Response{}
+	empty.Merge(&Response{
+		Weather:  map[string]Weather{"x": {TempF: 9}},
+		Pressure: map[string]Pressure{"x": {Trend: "rising"}},
+		Pollen:   map[string]Pollen{"x": {OverallIndex: 3}},
+	})
+	if empty.Weather["x"].TempF != 9 {
+		t.Error("Merge into nil Weather map failed")
+	}
+	if empty.Pressure["x"].Trend != "rising" {
+		t.Error("Merge into nil Pressure map failed")
+	}
+	if empty.Pollen["x"].OverallIndex != 3 {
+		t.Error("Merge into nil Pollen map failed")
+	}
+}

--- a/clients/cli/internal/client/types.go
+++ b/clients/cli/internal/client/types.go
@@ -9,6 +9,51 @@ type Response struct {
 	Pollen   map[string]Pollen   `json:"pollen"`
 }
 
+// Merge folds the entries from src into r using last-write-wins semantics:
+// for each key present in src, the entry is written into r only if it is
+// strictly newer than the entry already there (compared by per-payload
+// timestamp), or if r had no entry for that key. Keys absent from src are
+// left untouched.
+//
+// The timestamps come straight from the upstream payload (LastUpdated for
+// Weather/Pressure, CollectedAt for Pollen) and arrive as canonical RFC 3339
+// strings via protojson, so lexicographic > is equivalent to time.After.
+//
+// Why LWW: the TUI may have an in-flight full Fetch and an in-flight
+// FetchLocation arrive out of order — a stale full response that returns
+// after a fresh single-location response should not clobber the focused
+// location's newer data. Equal timestamps (the steady state today, since
+// upstream readings update hourly) skip the write entirely.
+func (r *Response) Merge(src *Response) {
+	if r == nil || src == nil {
+		return
+	}
+	if r.Weather == nil {
+		r.Weather = make(map[string]Weather, len(src.Weather))
+	}
+	for k, v := range src.Weather {
+		if existing, ok := r.Weather[k]; !ok || v.LastUpdated > existing.LastUpdated {
+			r.Weather[k] = v
+		}
+	}
+	if r.Pressure == nil {
+		r.Pressure = make(map[string]Pressure, len(src.Pressure))
+	}
+	for k, v := range src.Pressure {
+		if existing, ok := r.Pressure[k]; !ok || v.LastUpdated > existing.LastUpdated {
+			r.Pressure[k] = v
+		}
+	}
+	if r.Pollen == nil {
+		r.Pollen = make(map[string]Pollen, len(src.Pollen))
+	}
+	for k, v := range src.Pollen {
+		if existing, ok := r.Pollen[k]; !ok || v.CollectedAt > existing.CollectedAt {
+			r.Pollen[k] = v
+		}
+	}
+}
+
 // Weather matches the protojson output of the dashboard-api weather payload.
 type Weather struct {
 	LocationID           string  `json:"locationId"`

--- a/clients/cli/internal/tui/model.go
+++ b/clients/cli/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -12,11 +13,31 @@ import (
 	"github.com/nickfang/personal-dashboard/clients/cli/internal/client"
 )
 
-// refreshMsg is emitted on each tick — triggers a new fetch.
+// statusFlashTTL is how long a transient status-bar flash message stays
+// visible before being cleared on the next render.
+const statusFlashTTL = 5 * time.Second
+
+// viewMode describes what the TUI is currently rendering.
+type viewMode int
+
+const (
+	viewAll viewMode = iota
+	viewSingle
+)
+
+// refreshMsg is emitted on each tick — triggers a new full-dashboard fetch.
 type refreshMsg time.Time
 
-// fetchResultMsg carries the outcome of a dashboard fetch.
+// fetchResultMsg carries the outcome of a full-dashboard fetch.
 type fetchResultMsg struct {
+	data *client.Response
+	err  error
+	at   time.Time
+}
+
+// fetchLocationResultMsg carries the outcome of a single-location fetch.
+// The result is merged into the cached Response rather than replacing it.
+type fetchLocationResultMsg struct {
 	data *client.Response
 	err  error
 	at   time.Time
@@ -31,11 +52,21 @@ type Model struct {
 	data      *client.Response
 	err       error
 	lastFetch time.Time
+
+	mode         viewMode
+	selectedIdx  int
+	initialLocID string // -location flag value; consumed on first successful fetch
+
+	statusFlash   string
+	statusFlashAt time.Time
 }
 
-// NewModel constructs a Model ready to run under tea.NewProgram.
-func NewModel(c *client.Client, refresh time.Duration) Model {
-	return Model{client: c, refresh: refresh}
+// NewModel constructs a Model ready to run under tea.NewProgram. If
+// initialLocID is non-empty, the model will switch to single-location view
+// for that ID after the first successful fetch (or surface a flash message
+// if the ID isn't present in the response).
+func NewModel(c *client.Client, refresh time.Duration, initialLocID string) Model {
+	return Model{client: c, refresh: refresh, initialLocID: initialLocID}
 }
 
 // Init returns the initial commands: an immediate fetch and a periodic tick.
@@ -43,13 +74,21 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(m.fetchCmd(), m.tickCmd())
 }
 
-// fetchCmd returns a tea.Cmd that performs a fetch (with a 10s timeout) in the background.
+// fetchCmd returns a tea.Cmd that performs a full-dashboard fetch in the
+// background. Timeout is owned by the client (client.DefaultTimeout) so
+// the tea.Cmd doesn't duplicate that policy here.
 func (m Model) fetchCmd() tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		data, err := m.client.Fetch(ctx)
+		data, err := m.client.Fetch(context.Background())
 		return fetchResultMsg{data: data, err: err, at: time.Now()}
+	}
+}
+
+// fetchLocationCmd returns a tea.Cmd that fetches just one location.
+func (m Model) fetchLocationCmd(locationID string) tea.Cmd {
+	return func() tea.Msg {
+		data, err := m.client.FetchLocation(context.Background(), locationID)
+		return fetchLocationResultMsg{data: data, err: err, at: time.Now()}
 	}
 }
 
@@ -69,27 +108,126 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "ctrl+c", "esc":
-			return m, tea.Quit
-		}
-		return m, nil
+		return m.handleKey(msg)
 
 	case refreshMsg:
-		// Kick off a fetch and schedule the next tick.
+		// Tick refresh always pulls the full dashboard so navigation stays
+		// instant from cache regardless of which view we're in.
 		return m, tea.Batch(m.fetchCmd(), m.tickCmd())
 
 	case fetchResultMsg:
 		if msg.err != nil {
 			m.err = msg.err
-		} else {
-			m.err = nil
-			m.data = msg.data
-			m.lastFetch = msg.at
+			return m, nil
 		}
+		m.err = nil
+		m.data = msg.data
+		m.lastFetch = msg.at
+		m.consumeInitialLocation()
+		m.clampSelection()
+		return m, nil
+
+	case fetchLocationResultMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.err = nil
+		if m.data == nil {
+			m.data = msg.data
+		} else {
+			m.data.Merge(msg.data)
+		}
+		m.lastFetch = msg.at
 		return m, nil
 	}
 	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c", "esc":
+		return m, tea.Quit
+
+	case "left", "right":
+		ids := locationIDs(m.data)
+		if len(ids) == 0 {
+			return m, nil
+		}
+		if m.mode == viewAll {
+			m.mode = viewSingle
+			if msg.String() == "right" {
+				m.selectedIdx = 0
+			} else {
+				m.selectedIdx = len(ids) - 1
+			}
+			return m, nil
+		}
+		if msg.String() == "right" {
+			m.selectedIdx = (m.selectedIdx + 1) % len(ids)
+		} else {
+			m.selectedIdx = (m.selectedIdx - 1 + len(ids)) % len(ids)
+		}
+		return m, nil
+
+	case "up":
+		if m.mode == viewSingle {
+			m.mode = viewAll
+		}
+		return m, nil
+
+	case "r":
+		if m.mode == viewAll {
+			return m, m.fetchCmd()
+		}
+		ids := locationIDs(m.data)
+		if len(ids) == 0 {
+			return m, m.fetchCmd()
+		}
+		if m.selectedIdx >= len(ids) {
+			m.selectedIdx = len(ids) - 1
+		}
+		return m, m.fetchLocationCmd(ids[m.selectedIdx])
+	}
+	return m, nil
+}
+
+// consumeInitialLocation runs after the first successful full-dashboard
+// fetch. If the user supplied -location=ID and that ID is present in the
+// response, switch to single-location view for it. Otherwise emit a
+// non-fatal flash message and stay on "all".
+func (m *Model) consumeInitialLocation() {
+	if m.initialLocID == "" {
+		return
+	}
+	ids := locationIDs(m.data)
+	for i, id := range ids {
+		if id == m.initialLocID {
+			m.mode = viewSingle
+			m.selectedIdx = i
+			m.initialLocID = ""
+			return
+		}
+	}
+	m.statusFlash = fmt.Sprintf("location %q not found, showing all", m.initialLocID)
+	m.statusFlashAt = time.Now()
+	m.initialLocID = ""
+}
+
+// clampSelection keeps selectedIdx in range when the set of locations
+// changes between fetches (e.g. a provider drops a location).
+func (m *Model) clampSelection() {
+	ids := locationIDs(m.data)
+	if len(ids) == 0 {
+		m.selectedIdx = 0
+		return
+	}
+	if m.selectedIdx >= len(ids) {
+		m.selectedIdx = len(ids) - 1
+	}
+	if m.selectedIdx < 0 {
+		m.selectedIdx = 0
+	}
 }
 
 // View renders the full TUI.
@@ -98,7 +236,6 @@ func (m Model) View() string {
 		return ""
 	}
 
-	// Compute frame width: cap to something sane, leave margin.
 	frameWidth := m.width - 4
 	if frameWidth < 40 {
 		frameWidth = m.width
@@ -111,7 +248,6 @@ func (m Model) View() string {
 	b.WriteString(renderHeader(frameWidth))
 	b.WriteString("\n\n")
 
-	// Inner width inside each location box: frameWidth minus the box's own border padding.
 	innerWidth := frameWidth - 4
 	if innerWidth < 30 {
 		innerWidth = 30
@@ -122,27 +258,74 @@ func (m Model) View() string {
 		b.WriteString("  Loading dashboard data...\n\n")
 	}
 
-	for _, id := range ids {
-		var w *client.Weather
-		var p *client.Pressure
-		var pol *client.Pollen
-		if v, ok := m.data.Weather[id]; ok {
-			w = &v
+	switch m.mode {
+	case viewSingle:
+		if len(ids) > 0 {
+			idx := m.selectedIdx
+			if idx >= len(ids) {
+				idx = len(ids) - 1
+			}
+			id := ids[idx]
+			b.WriteString(renderLocation(id, weatherFor(m.data, id), pressureFor(m.data, id), pollenFor(m.data, id), innerWidth))
+			b.WriteString("\n\n")
 		}
-		if v, ok := m.data.Pressure[id]; ok {
-			p = &v
+	default:
+		for _, id := range ids {
+			b.WriteString(renderLocation(id, weatherFor(m.data, id), pressureFor(m.data, id), pollenFor(m.data, id), innerWidth))
+			b.WriteString("\n\n")
 		}
-		if v, ok := m.data.Pollen[id]; ok {
-			pol = &v
-		}
-		b.WriteString(renderLocation(id, w, p, pol, innerWidth))
-		b.WriteString("\n\n")
 	}
 
-	b.WriteString(renderStatus(m.refresh, m.lastFetch, m.err))
+	flash := m.statusFlash
+	if flash != "" && time.Since(m.statusFlashAt) > statusFlashTTL {
+		flash = ""
+	}
+	focusID := ""
+	idx, total := 0, len(ids)
+	if m.mode == viewSingle && total > 0 {
+		i := m.selectedIdx
+		if i >= total {
+			i = total - 1
+		}
+		focusID = ids[i]
+		idx = i
+	}
+	b.WriteString(renderStatus(m.refresh, m.lastFetch, m.err, m.mode, focusID, idx, total, flash))
 
-	// Center horizontally.
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Top, b.String())
+}
+
+// weatherFor returns a pointer to the weather entry for id, or nil if absent.
+func weatherFor(r *client.Response, id string) *client.Weather {
+	if r == nil {
+		return nil
+	}
+	if v, ok := r.Weather[id]; ok {
+		return &v
+	}
+	return nil
+}
+
+// pressureFor returns a pointer to the pressure entry for id, or nil if absent.
+func pressureFor(r *client.Response, id string) *client.Pressure {
+	if r == nil {
+		return nil
+	}
+	if v, ok := r.Pressure[id]; ok {
+		return &v
+	}
+	return nil
+}
+
+// pollenFor returns a pointer to the pollen entry for id, or nil if absent.
+func pollenFor(r *client.Response, id string) *client.Pollen {
+	if r == nil {
+		return nil
+	}
+	if v, ok := r.Pollen[id]; ok {
+		return &v
+	}
+	return nil
 }
 
 // locationIDs returns the union of location IDs present in the response,

--- a/clients/cli/internal/tui/render_test.go
+++ b/clients/cli/internal/tui/render_test.go
@@ -159,15 +159,67 @@ func TestRenderPollen(t *testing.T) {
 
 func TestRenderStatus(t *testing.T) {
 	ts := time.Date(2026, 4, 11, 14, 30, 5, 0, time.UTC)
-	got := renderStatus(60*time.Second, ts, nil)
-	for _, s := range []string{"1m0s", "14:30:05", "q: quit", "Refreshing"} {
+	got := renderStatus(60*time.Second, ts, nil, viewAll, "", 0, 0, "")
+	for _, s := range []string{"1m0s", "14:30:05", "q quit", "Refreshing"} {
 		if !strings.Contains(got, s) {
 			t.Errorf("missing %q:\n%s", s, got)
 		}
 	}
-	got = renderStatus(60*time.Second, ts, errors.New("boom"))
+	got = renderStatus(60*time.Second, ts, errors.New("boom"), viewAll, "", 0, 0, "")
 	if !strings.Contains(got, "Error:") || !strings.Contains(got, "boom") {
 		t.Errorf("expected error status, got: %q", got)
+	}
+	// Error must NOT hide the contextual bar — the user needs nav hints
+	// to escape single-view (or otherwise act) even while an error is up.
+	if !strings.Contains(got, "Refreshing") {
+		t.Errorf("expected status bar to still render alongside error: %q", got)
+	}
+	if !strings.Contains(got, "← → focus") {
+		t.Errorf("expected nav hints to still render alongside error: %q", got)
+	}
+}
+
+func TestRenderStatus_ErrorPreservesSingleViewHints(t *testing.T) {
+	ts := time.Date(2026, 4, 11, 14, 30, 5, 0, time.UTC)
+	got := renderStatus(60*time.Second, ts, errors.New("boom"), viewSingle, "house-nick", 0, 3, "")
+	for _, s := range []string{"Error:", "boom", "house-nick", "(1/3)", "↑ all"} {
+		if !strings.Contains(got, s) {
+			t.Errorf("missing %q in error+single-view render:\n%s", s, got)
+		}
+	}
+}
+
+func TestRenderStatus_AllViewContextualHints(t *testing.T) {
+	ts := time.Date(2026, 4, 11, 14, 30, 5, 0, time.UTC)
+	got := renderStatus(60*time.Second, ts, nil, viewAll, "", 0, 3, "")
+	for _, s := range []string{"← → focus", "r refresh", "q quit"} {
+		if !strings.Contains(got, s) {
+			t.Errorf("missing %q in all-view hints:\n%s", s, got)
+		}
+	}
+	if strings.Contains(got, "↑ all") {
+		t.Errorf("all-view should not show '↑ all' escape hint:\n%s", got)
+	}
+}
+
+func TestRenderStatus_SingleViewContextualHints(t *testing.T) {
+	ts := time.Date(2026, 4, 11, 14, 30, 5, 0, time.UTC)
+	got := renderStatus(60*time.Second, ts, nil, viewSingle, "house-nick", 1, 3, "")
+	for _, s := range []string{"house-nick", "(2/3)", "← → cycle", "↑ all", "r refresh", "q quit"} {
+		if !strings.Contains(got, s) {
+			t.Errorf("missing %q in single-view hints:\n%s", s, got)
+		}
+	}
+}
+
+func TestRenderStatus_FlashPrepended(t *testing.T) {
+	ts := time.Date(2026, 4, 11, 14, 30, 5, 0, time.UTC)
+	got := renderStatus(60*time.Second, ts, nil, viewAll, "", 0, 0, "location \"bogus\" not found")
+	if !strings.Contains(got, "bogus") {
+		t.Errorf("expected flash text in output:\n%s", got)
+	}
+	if !strings.Contains(got, "Refreshing") {
+		t.Errorf("expected status bar still rendered alongside flash:\n%s", got)
 	}
 }
 
@@ -215,7 +267,7 @@ func TestFormatTimestamp(t *testing.T) {
 }
 
 func TestModelUpdateQuit(t *testing.T) {
-	m := NewModel(nil, time.Minute)
+	m := NewModel(nil, time.Minute, "")
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	if cmd == nil {
 		t.Fatal("expected Quit cmd on q")
@@ -227,7 +279,7 @@ func TestModelUpdateQuit(t *testing.T) {
 }
 
 func TestModelUpdateWindowSize(t *testing.T) {
-	m := NewModel(nil, time.Minute)
+	m := NewModel(nil, time.Minute, "")
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	m2 := updated.(Model)
 	if m2.width != 120 || m2.height != 40 {
@@ -236,14 +288,158 @@ func TestModelUpdateWindowSize(t *testing.T) {
 }
 
 func TestModelViewEmptyWhenNoSize(t *testing.T) {
-	m := NewModel(nil, time.Minute)
+	m := NewModel(nil, time.Minute, "")
 	if got := m.View(); got != "" {
 		t.Errorf("expected empty view pre-WindowSizeMsg, got %q", got)
 	}
 }
 
+func TestModelNavigation_AllToSingleAndWrap(t *testing.T) {
+	data := &client.Response{
+		Weather: map[string]client.Weather{
+			"a-loc": {}, "b-loc": {}, "c-loc": {},
+		},
+	}
+	m := NewModel(nil, time.Minute, "")
+	tm, _ := m.Update(fetchResultMsg{data: data, at: time.Now()})
+	m = tm.(Model)
+
+	// Right from "all" enters first single (alphabetical: a-loc).
+	tm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = tm.(Model)
+	if m.mode != viewSingle || m.selectedIdx != 0 {
+		t.Fatalf("after right from all: mode=%v idx=%d, want single/0", m.mode, m.selectedIdx)
+	}
+
+	// Right twice → b-loc → c-loc.
+	tm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = tm.(Model)
+	if m.selectedIdx != 1 {
+		t.Errorf("after second right: idx=%d, want 1", m.selectedIdx)
+	}
+	tm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = tm.(Model)
+	if m.selectedIdx != 2 {
+		t.Errorf("after third right: idx=%d, want 2", m.selectedIdx)
+	}
+
+	// Right from last wraps to first.
+	tm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = tm.(Model)
+	if m.selectedIdx != 0 {
+		t.Errorf("after wrap right: idx=%d, want 0", m.selectedIdx)
+	}
+
+	// Left from first wraps to last.
+	tm, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	m = tm.(Model)
+	if m.selectedIdx != 2 {
+		t.Errorf("after wrap left: idx=%d, want 2", m.selectedIdx)
+	}
+
+	// Up returns to all.
+	tm, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = tm.(Model)
+	if m.mode != viewAll {
+		t.Errorf("after up: mode=%v, want viewAll", m.mode)
+	}
+
+	// Up while already on all is a no-op.
+	tm, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = tm.(Model)
+	if m.mode != viewAll {
+		t.Errorf("after second up: mode=%v, want viewAll", m.mode)
+	}
+}
+
+func TestModelNavigation_LeftFromAllEntersLast(t *testing.T) {
+	data := &client.Response{
+		Weather: map[string]client.Weather{"a-loc": {}, "b-loc": {}, "c-loc": {}},
+	}
+	m := NewModel(nil, time.Minute, "")
+	tm, _ := m.Update(fetchResultMsg{data: data, at: time.Now()})
+	m = tm.(Model)
+
+	tm, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	m = tm.(Model)
+	if m.mode != viewSingle || m.selectedIdx != 2 {
+		t.Errorf("after left from all: mode=%v idx=%d, want single/2", m.mode, m.selectedIdx)
+	}
+}
+
+func TestModelNavigation_NoOpsWhenNoData(t *testing.T) {
+	m := NewModel(nil, time.Minute, "")
+
+	for _, key := range []tea.KeyType{tea.KeyLeft, tea.KeyRight, tea.KeyUp} {
+		tm, _ := m.Update(tea.KeyMsg{Type: key})
+		next := tm.(Model)
+		if next.mode != viewAll {
+			t.Errorf("key %v with no data should not change mode (got %v)", key, next.mode)
+		}
+	}
+}
+
+func TestModelRefreshKey_ViewAware(t *testing.T) {
+	data := &client.Response{
+		Weather: map[string]client.Weather{"a-loc": {}, "b-loc": {}},
+	}
+	m := NewModel(nil, time.Minute, "")
+	tm, _ := m.Update(fetchResultMsg{data: data, at: time.Now()})
+	m = tm.(Model)
+
+	// In viewAll, 'r' returns a non-nil cmd (the full fetch).
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Error("expected r in viewAll to return a command")
+	}
+
+	// Move into single view, then 'r' should still return a non-nil cmd
+	// (the per-location fetch). We can't easily distinguish the cmd type
+	// without invoking it (which would hit the network), so the contract
+	// here is just "r produces work".
+	tm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = tm.(Model)
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Error("expected r in viewSingle to return a command")
+	}
+}
+
+func TestModelFetchLocationResult_MergesIntoCachedData(t *testing.T) {
+	// LWW merge requires timestamps: real API responses always carry them,
+	// so the fixtures mirror that. Original is older; the single-location
+	// refresh result is newer and therefore wins.
+	const olderTS = "2026-04-13T13:00:00Z"
+	const newerTS = "2026-04-13T14:30:05Z"
+
+	original := &client.Response{
+		Weather: map[string]client.Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: olderTS, TempF: 70.0},
+			"house-nita": {LocationID: "house-nita", LastUpdated: olderTS, TempF: 71.0},
+		},
+	}
+	m := NewModel(nil, time.Minute, "")
+	tm, _ := m.Update(fetchResultMsg{data: original, at: time.Now()})
+	m = tm.(Model)
+
+	updated := &client.Response{
+		Weather: map[string]client.Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: newerTS, TempF: 99.9},
+		},
+	}
+	tm, _ = m.Update(fetchLocationResultMsg{data: updated, at: time.Now()})
+	m = tm.(Model)
+
+	if got := m.data.Weather["house-nick"].TempF; got != 99.9 {
+		t.Errorf("Weather[house-nick].TempF = %v, want merged 99.9", got)
+	}
+	if got := m.data.Weather["house-nita"].TempF; got != 71.0 {
+		t.Errorf("Weather[house-nita].TempF = %v, want preserved 71.0 (single-location merge should not clobber unrelated locations)", got)
+	}
+}
+
 func TestModelFetchResult(t *testing.T) {
-	m := NewModel(nil, time.Minute)
+	m := NewModel(nil, time.Minute, "")
 	now := time.Now()
 	updated, _ := m.Update(fetchResultMsg{data: &client.Response{}, err: nil, at: now})
 	m2 := updated.(Model)

--- a/clients/cli/internal/tui/status.go
+++ b/clients/cli/internal/tui/status.go
@@ -2,20 +2,54 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
-// renderStatus renders the bottom status bar.
-func renderStatus(refresh time.Duration, lastFetch time.Time, err error) string {
-	if err != nil {
-		return ErrorStyle.Render(fmt.Sprintf("Error: %s │ q: quit", err.Error()))
-	}
+// renderStatus renders the bottom status bar. The hints adapt to the current
+// view: in viewAll the hints suggest entering single-view; in viewSingle they
+// show the focused location, position indicator, and how to escape.
+//
+// err and flash, when present, render as their own lines stacked above the
+// contextual bar. The contextual bar (with nav hints) is always rendered, so
+// the user can always see how to navigate even while an error is on screen.
+func renderStatus(refresh time.Duration, lastFetch time.Time, err error,
+	mode viewMode, focusID string, idx, total int, flash string) string {
+	// "Last fetch" reflects the wall-clock time of the most recent
+	// *successful* fetch, not the most recent attempt. Failed fetches set
+	// m.err but leave lastFetch untouched (see model.go's fetchResultMsg
+	// and fetchLocationResultMsg handlers), so this timestamp is what the
+	// user can trust the rendered data to be from.
 	last := "never"
 	if !lastFetch.IsZero() {
 		last = lastFetch.Format("15:04:05")
 	}
-	return StatusBarStyle.Render(fmt.Sprintf(
-		"Refreshing every %s │ Last fetch: %s │ q: quit",
-		refresh.String(), last,
+
+	var hint string
+	switch mode {
+	case viewSingle:
+		if total > 0 && focusID != "" {
+			hint = fmt.Sprintf("%s (%d/%d)  ← → cycle  ↑ all  r refresh  q quit",
+				focusID, idx+1, total)
+		} else {
+			hint = "← → cycle  ↑ all  r refresh  q quit"
+		}
+	default:
+		hint = "← → focus  r refresh  q quit"
+	}
+
+	bar := StatusBarStyle.Render(fmt.Sprintf(
+		"Refreshing every %s │ Last fetch: %s │ %s",
+		refresh.String(), last, hint,
 	))
+
+	var lines []string
+	if err != nil {
+		lines = append(lines, ErrorStyle.Render(fmt.Sprintf("Error: %s", err.Error())))
+	}
+	if flash != "" {
+		lines = append(lines, StatusBarStyle.Render(flash))
+	}
+	lines = append(lines, bar)
+	return strings.Join(lines, "\n")
 }

--- a/clients/cli/internal/tui/view_integration_test.go
+++ b/clients/cli/internal/tui/view_integration_test.go
@@ -1,7 +1,10 @@
 package tui
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,7 +34,7 @@ func TestModelView_FullRenderWithStagingShapedData(t *testing.T) {
 		},
 	}
 
-	m := NewModel(nil, 60*time.Second)
+	m := NewModel(nil, 60*time.Second, "")
 	var tm tea.Model = m
 	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 110, Height: 60})
 	tm, _ = tm.Update(fetchResultMsg{data: resp, at: time.Now()})
@@ -48,7 +51,7 @@ func TestModelView_FullRenderWithStagingShapedData(t *testing.T) {
 		"Rising",
 		"Oak (In Season)",
 		"Refreshing every",
-		"q: quit",
+		"q quit",
 	}
 	for _, s := range mustContain {
 		if !strings.Contains(view, s) {
@@ -58,5 +61,159 @@ func TestModelView_FullRenderWithStagingShapedData(t *testing.T) {
 
 	if strings.Contains(view, "Cottonwood") {
 		t.Errorf("Cottonwood should be filtered (index 0) but appeared in view")
+	}
+}
+
+func TestModelView_SingleLocationViewRendersOnlyFocused(t *testing.T) {
+	resp := &client.Response{
+		Weather: map[string]client.Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: "2026-04-15T02:02:08Z", TempF: 75.4, HumidityPercent: 71, PressureMb: 1013.58},
+			"house-nita": {LocationID: "house-nita", LastUpdated: "2026-04-15T02:02:08Z", TempF: 76.5, HumidityPercent: 68, PressureMb: 1013.55},
+		},
+		Pressure: map[string]client.Pressure{
+			"house-nick": {LocationID: "house-nick", Trend: "rising"},
+			"house-nita": {LocationID: "house-nita", Trend: "rising"},
+		},
+	}
+
+	m := NewModel(nil, 60*time.Second, "")
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 110, Height: 60})
+	tm, _ = tm.Update(fetchResultMsg{data: resp, at: time.Now()})
+	// Right arrow from "all" enters first single view (house-nick by sort order).
+	tm, _ = tm.Update(tea.KeyMsg{Type: tea.KeyRight})
+
+	view := tm.View()
+	if !strings.Contains(view, "house-nick") {
+		t.Errorf("expected house-nick in single view:\n%s", view)
+	}
+	if strings.Contains(view, "house-nita") {
+		t.Errorf("expected house-nita to be filtered out in single view:\n%s", view)
+	}
+	for _, s := range []string{"(1/2)", "← → cycle", "↑ all"} {
+		if !strings.Contains(view, s) {
+			t.Errorf("expected single-view hint %q:\n%s", s, view)
+		}
+	}
+}
+
+func TestModel_InitialLocationFocusesOnFirstFetch(t *testing.T) {
+	resp := &client.Response{
+		Weather: map[string]client.Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: "2026-04-15T02:02:08Z", TempF: 75.4, PressureMb: 1013.58},
+			"house-nita": {LocationID: "house-nita", LastUpdated: "2026-04-15T02:02:08Z", TempF: 76.5, PressureMb: 1013.55},
+		},
+		Pressure: map[string]client.Pressure{
+			"house-nick": {Trend: "rising"},
+			"house-nita": {Trend: "rising"},
+		},
+	}
+
+	m := NewModel(nil, 60*time.Second, "house-nita")
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 110, Height: 60})
+	tm, _ = tm.Update(fetchResultMsg{data: resp, at: time.Now()})
+
+	view := tm.View()
+	if !strings.Contains(view, "house-nita") {
+		t.Errorf("expected house-nita to be focused per -location flag:\n%s", view)
+	}
+	if strings.Contains(view, "house-nick") {
+		// "house-nick" wouldn't appear as a location box but might appear in
+		// e.g. logs. The reliable check is that the position indicator is for nita.
+	}
+	if !strings.Contains(view, "(2/2)") {
+		t.Errorf("expected position (2/2) for house-nita (alphabetical second):\n%s", view)
+	}
+}
+
+// TestModel_RefreshKeyHitsRightEndpointPerView locks in the view-aware
+// refresh contract from issue #60: pressing 'r' in viewAll re-fetches the
+// full /v1/dashboard, while pressing 'r' in viewSingle re-fetches only
+// /v1/dashboard/{focusedID}. Drives the model through a real *client.Client
+// pointed at an httptest server so the assertion is on the actual wire path.
+func TestModel_RefreshKeyHitsRightEndpointPerView(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"weather":  {"house-nick": {"locationId":"house-nick","lastUpdated":"2026-04-15T02:02:08Z","tempF":75}},
+			"pressure": {"house-nick": {"locationId":"house-nick","lastUpdated":"2026-04-15T02:02:08Z","trend":"rising"}},
+			"pollen":   {}
+		}`))
+	}))
+	defer srv.Close()
+
+	c, err := client.New(srv.URL)
+	if err != nil {
+		t.Fatalf("client.New: %v", err)
+	}
+
+	// Seed cached data so single view has something to focus on without
+	// having to round-trip the test server first.
+	seed := &client.Response{
+		Weather: map[string]client.Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: "2026-04-15T02:02:08Z", TempF: 75},
+		},
+	}
+	m := NewModel(c, 60*time.Second, "")
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 110, Height: 60})
+	tm, _ = tm.Update(fetchResultMsg{data: seed, at: time.Now()})
+
+	// 'r' in all view → /v1/dashboard
+	_, cmd := tm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	if cmd == nil {
+		t.Fatal("expected refresh cmd in all view, got nil")
+	}
+	// tea.Cmds wrap the actual work in a closure; invoking it synchronously
+	// here drives the HTTP call through the real client to the test server.
+	cmd()
+
+	// Right arrow enters single view focused on the (only) seeded location.
+	tm, _ = tm.Update(tea.KeyMsg{Type: tea.KeyRight})
+
+	// 'r' in single view → /v1/dashboard/house-nick
+	_, cmd = tm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	if cmd == nil {
+		t.Fatal("expected refresh cmd in single view, got nil")
+	}
+	cmd()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 server hits, got %d: %v", len(paths), paths)
+	}
+	if paths[0] != "/v1/dashboard" {
+		t.Errorf("first refresh (all view) hit %q, want /v1/dashboard", paths[0])
+	}
+	if paths[1] != "/v1/dashboard/house-nick" {
+		t.Errorf("second refresh (single view) hit %q, want /v1/dashboard/house-nick", paths[1])
+	}
+}
+
+func TestModel_InitialLocationMissShowsFlash(t *testing.T) {
+	resp := &client.Response{
+		Weather: map[string]client.Weather{
+			"house-nick": {LocationID: "house-nick", LastUpdated: "2026-04-15T02:02:08Z", TempF: 75.4},
+		},
+	}
+
+	m := NewModel(nil, 60*time.Second, "bogus-location")
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 110, Height: 60})
+	tm, _ = tm.Update(fetchResultMsg{data: resp, at: time.Now()})
+
+	view := tm.View()
+	if !strings.Contains(view, "bogus-location") {
+		t.Errorf("expected flash mentioning the missing location:\n%s", view)
+	}
+	if !strings.Contains(view, "← → focus") {
+		t.Errorf("expected fallback to all-view hints:\n%s", view)
 	}
 }

--- a/services/dashboard-api/internal/app/router.go
+++ b/services/dashboard-api/internal/app/router.go
@@ -21,6 +21,7 @@ func NewRouter(dashboardHandler *handlers.DashboardHandler) *chi.Mux {
 	// API Routes
 	r.Route("/v1", func(r chi.Router) {
 		r.Get("/dashboard", dashboardHandler.GetDashboard)
+		r.Get("/dashboard/{locationID}", dashboardHandler.GetDashboardByLocation)
 		// r.Get("/weather", dashboardHandler.GetWeather)
 		// r.Get("/pollen", dashboardHandler.GetPollen)
 	})

--- a/services/dashboard-api/internal/handlers/errors.go
+++ b/services/dashboard-api/internal/handlers/errors.go
@@ -8,6 +8,18 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// isNotFound reports whether err is a gRPC NotFound status. Used by
+// per-section fan-outs (e.g. GetDashboardByLocation) that want to treat
+// "this provider has no data for that location" as "skip this section"
+// rather than "fail the whole request."
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	st, ok := status.FromError(err)
+	return ok && st.Code() == codes.NotFound
+}
+
 // RespondWithGrpcError maps a gRPC error to a standard HTTP response.
 func RespondWithGrpcError(w http.ResponseWriter, err error, message string) {
 	st, ok := status.FromError(err)

--- a/services/dashboard-api/internal/handlers/handler.go
+++ b/services/dashboard-api/internal/handlers/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
 	"golang.org/x/sync/errgroup"
 
 	pollenPb "github.com/nickfang/personal-dashboard/services/dashboard-api/internal/gen/go/pollen-provider/v1"
@@ -145,6 +146,122 @@ func (h *DashboardHandler) GetDashboard(w http.ResponseWriter, r *http.Request) 
 	// 4. Respond with JSON (encoding/json handles json.RawMessage values
 	// by embedding them verbatim, so the protojson output passes through).
 	// Marshal to buffer first so we can return a clean 500 if encoding fails.
+	buf, err := json.Marshal(map[string]any{
+		"weather":  aggregatedLastWeather,
+		"pressure": aggregatedPressure,
+		"pollen":   aggregatedPollen,
+	})
+	if err != nil {
+		http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(buf)
+}
+
+func (h *DashboardHandler) GetDashboardByLocation(w http.ResponseWriter, r *http.Request) {
+	// Chi's path matching guarantees a non-empty {locationID} segment
+	// before the handler runs, so we don't re-validate emptiness here.
+	locationID := chi.URLParam(r, "locationID")
+
+	var pressureStat *pressurePb.PressureStat
+	var pollenReport *pollenPb.PollenReport
+	var lastWeather *pressurePb.Weather
+
+	g, ctx := errgroup.WithContext(r.Context())
+
+	// Each goroutine swallows a NotFound error (treated as "no data for
+	// this section, but the request as a whole is still valid") and lets
+	// every other error propagate so errgroup can cancel its siblings and
+	// fail the whole request. (nil, nil) returns from a misbehaving
+	// provider also fall through as "section absent" — no panic, just no
+	// data, same shape as a clean NotFound.
+	g.Go(func() error {
+		rpcCtx, cancel := context.WithTimeout(ctx, shared.RPCClientTimeout)
+		defer cancel()
+		s, err := h.weatherClient.GetPressureStat(rpcCtx, locationID)
+		if isNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		pressureStat = s
+		return nil
+	})
+	g.Go(func() error {
+		rpcCtx, cancel := context.WithTimeout(ctx, shared.RPCClientTimeout)
+		defer cancel()
+		lw, err := h.weatherClient.GetLastWeather(rpcCtx, locationID)
+		if isNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		lastWeather = lw
+		return nil
+	})
+	g.Go(func() error {
+		rpcCtx, cancel := context.WithTimeout(ctx, shared.RPCClientTimeout)
+		defer cancel()
+		p, err := h.pollenClient.GetPollenReport(rpcCtx, locationID)
+		if isNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		pollenReport = p
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		RespondWithGrpcError(w, err, "Failed to fetch dashboard data for location")
+		return
+	}
+
+	// 404 only when the location is wholly absent across all three sections.
+	// Partial data (e.g. weather present but pollen NotFound) yields 200
+	// with the corresponding maps left empty for the absent sections.
+	if pressureStat == nil && lastWeather == nil && pollenReport == nil {
+		http.Error(w, "Location data not found", http.StatusNotFound)
+		return
+	}
+
+	// Build aggregate inputs only from sections that actually returned data —
+	// a one-element slice per present section, nil for absent ones. The
+	// aggregate helpers iterate the slice, so nil-input maps come out empty,
+	// which is exactly the partial-data shape we want.
+	var pressureSlice []*pressurePb.PressureStat
+	if pressureStat != nil {
+		pressureSlice = []*pressurePb.PressureStat{pressureStat}
+	}
+	var weatherSlice []*pressurePb.Weather
+	if lastWeather != nil {
+		weatherSlice = []*pressurePb.Weather{lastWeather}
+	}
+	var pollenSlice []*pollenPb.PollenReport
+	if pollenReport != nil {
+		pollenSlice = []*pollenPb.PollenReport{pollenReport}
+	}
+
+	aggregatedPressure, err := aggregatePressureStats(pressureSlice)
+	if err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+	aggregatedPollen, err := aggregatePollenReports(pollenSlice)
+	if err != nil {
+		http.Error(w, "Failed to encode pollen response", http.StatusInternalServerError)
+		return
+	}
+	aggregatedLastWeather, err := aggregateLastWeather(weatherSlice)
+	if err != nil {
+		http.Error(w, "Failed to encode last weather response", http.StatusInternalServerError)
+		return
+	}
+
 	buf, err := json.Marshal(map[string]any{
 		"weather":  aggregatedLastWeather,
 		"pressure": aggregatedPressure,

--- a/services/dashboard-api/internal/handlers/handler_test.go
+++ b/services/dashboard-api/internal/handlers/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	pollenPb "github.com/nickfang/personal-dashboard/services/dashboard-api/internal/gen/go/pollen-provider/v1"
 	weatherPb "github.com/nickfang/personal-dashboard/services/dashboard-api/internal/gen/go/weather-provider/v1"
 	"github.com/nickfang/personal-dashboard/services/shared"
@@ -17,6 +18,23 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// requestWithLocationID returns an *http.Request whose chi RouteContext has
+// the {locationID} URL param set to the given value, simulating chi's router
+// without routing through chi.NewRouter. Pass an empty string to simulate a
+// request whose param was never populated.
+func requestWithLocationID(t *testing.T, locationID string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest("GET", "/api/v1/dashboard/"+locationID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rctx := chi.NewRouteContext()
+	if locationID != "" {
+		rctx.URLParams.Add("locationID", locationID)
+	}
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
 
 // --- Weather mocks ---
 
@@ -667,4 +685,248 @@ func keys(m map[string]interface{}) []string {
 		result = append(result, k)
 	}
 	return result
+}
+
+// --- GetDashboardByLocation tests ---
+
+func TestDashboardHandler_GetDashboardByLocation_Success(t *testing.T) {
+	handler := NewDashboardHandler(&mockWeatherClient{}, &mockPollenClient{})
+	req := requestWithLocationID(t, "house-nick")
+	rr := httptest.NewRecorder()
+
+	handler.GetDashboardByLocation(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to decode JSON: %v", err)
+	}
+
+	for _, key := range []string{"weather", "pressure", "pollen"} {
+		section, ok := resp[key].(map[string]interface{})
+		if !ok {
+			t.Fatalf("Response missing %q object", key)
+		}
+		if len(section) != 1 {
+			t.Errorf("expected exactly one entry under %q, got %d (keys: %v)", key, len(section), keys(section))
+		}
+		if _, ok := section["house-nick"]; !ok {
+			t.Errorf("Response %q missing 'house-nick' entry (keys: %v)", key, keys(section))
+		}
+	}
+
+	weather := resp["weather"].(map[string]interface{})["house-nick"].(map[string]interface{})
+	if weather["tempC"] != 22.5 {
+		t.Errorf("Expected tempC 22.5, got %v", weather["tempC"])
+	}
+
+	pressure := resp["pressure"].(map[string]interface{})["house-nick"].(map[string]interface{})
+	if pressure["trend"] != "rising" {
+		t.Errorf("Expected trend 'rising', got %v", pressure["trend"])
+	}
+	if _, ok := pressure["locationId"]; !ok {
+		t.Errorf("expected camelCase 'locationId' from protojson, got keys: %v", keys(pressure))
+	}
+
+	pollen := resp["pollen"].(map[string]interface{})["house-nick"].(map[string]interface{})
+	if pollen["dominantType"] != "TREE" {
+		t.Errorf("Expected dominantType 'TREE', got %v", pollen["dominantType"])
+	}
+}
+
+// TestDashboardHandler_GetDashboardByLocation_GrpcError covers the *fatal*
+// gRPC error codes — the ones that should fail the whole request rather
+// than be tolerated as "section absent." NotFound is intentionally absent
+// from this table; per the partial-data contract, NotFound from any single
+// provider is non-fatal (see the PartialData / AllSectionsAbsent tests).
+func TestDashboardHandler_GetDashboardByLocation_GrpcError(t *testing.T) {
+	tests := []struct {
+		name           string
+		grpcErr        error
+		expectedStatus int
+	}{
+		{
+			name:           "Unavailable returns 503",
+			grpcErr:        status.Error(codes.Unavailable, "weather-provider down"),
+			expectedStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:           "DeadlineExceeded returns 504",
+			grpcErr:        status.Error(codes.DeadlineExceeded, "timeout"),
+			expectedStatus: http.StatusGatewayTimeout,
+		},
+		{
+			name:           "Unknown returns 500",
+			grpcErr:        status.Error(codes.Unknown, "unknown"),
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name:           "Non-gRPC error returns 500",
+			grpcErr:        fmt.Errorf("connection refused"),
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewDashboardHandler(&errorWeatherClient{err: tt.grpcErr}, &mockPollenClient{})
+			req := requestWithLocationID(t, "house-nick")
+			rr := httptest.NewRecorder()
+
+			handler.GetDashboardByLocation(rr, req)
+
+			if rr.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rr.Code)
+			}
+		})
+	}
+}
+
+// nilReturnWeatherClient returns (nil, nil) for every call — simulating a
+// misbehaving provider that responds with no error but also no data. Without
+// a defensive nil-check, the aggregate helpers would panic on the nil proto.
+type nilReturnWeatherClient struct{}
+
+func (m *nilReturnWeatherClient) GetPressureStat(ctx context.Context, locationID string) (*weatherPb.PressureStat, error) {
+	return nil, nil
+}
+func (m *nilReturnWeatherClient) GetPressureStats(ctx context.Context) ([]*weatherPb.PressureStat, error) {
+	return nil, nil
+}
+func (m *nilReturnWeatherClient) GetLastWeather(ctx context.Context, locationID string) (*weatherPb.Weather, error) {
+	return nil, nil
+}
+func (m *nilReturnWeatherClient) GetAllLastWeather(ctx context.Context) ([]*weatherPb.Weather, error) {
+	return nil, nil
+}
+
+// TestDashboardHandler_GetDashboardByLocation_PartialData_WeatherMissingPollenPresent
+// locks in the partial-data contract: when a provider returns (nil, nil)
+// for a location (weather/pressure here), we don't fail the request — we
+// return 200 with the absent sections rendered as empty JSON maps and the
+// present sections populated normally. This is the shape the CLI's
+// Response.Merge depends on (empty src maps are no-ops on the dst).
+func TestDashboardHandler_GetDashboardByLocation_PartialData_WeatherMissingPollenPresent(t *testing.T) {
+	handler := NewDashboardHandler(&nilReturnWeatherClient{}, &mockPollenClient{})
+	req := requestWithLocationID(t, "house-nick")
+	rr := httptest.NewRecorder()
+
+	handler.GetDashboardByLocation(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 with partial data, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	var body map[string]map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := len(body["weather"]); got != 0 {
+		t.Errorf("weather map should be empty (nil-provider section), got %d entries", got)
+	}
+	if got := len(body["pressure"]); got != 0 {
+		t.Errorf("pressure map should be empty (nil-provider section), got %d entries", got)
+	}
+	if _, ok := body["pollen"]["house-nick"]; !ok {
+		t.Errorf("pollen[house-nick] should be present, body: %s", rr.Body.String())
+	}
+}
+
+// TestDashboardHandler_GetDashboardByLocation_AllSectionsAbsent_Returns404
+// is the "wholly absent" boundary: when every provider signals NotFound,
+// there's nothing partial to return, so we surface 404 rather than a
+// confusingly-empty 200.
+func TestDashboardHandler_GetDashboardByLocation_AllSectionsAbsent_Returns404(t *testing.T) {
+	notFound := status.Error(codes.NotFound, "no data for location")
+	handler := NewDashboardHandler(
+		&errorWeatherClient{err: notFound},
+		&errorPollenClient{err: notFound},
+	)
+	req := requestWithLocationID(t, "house-nick")
+	rr := httptest.NewRecorder()
+
+	handler.GetDashboardByLocation(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 when every section is NotFound, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+// TestDashboardHandler_GetDashboardByLocation_PollenNotFound_PartialData
+// covers the per-section partial-data path from the other side: pollen is
+// the missing section this time, weather and pressure are populated.
+// Pairs with the WeatherMissingPollenPresent test above to lock in that
+// any single-section NotFound is non-fatal regardless of which one.
+func TestDashboardHandler_GetDashboardByLocation_PollenNotFound_PartialData(t *testing.T) {
+	handler := NewDashboardHandler(
+		&mockWeatherClient{},
+		&errorPollenClient{err: status.Error(codes.NotFound, "no pollen for location")},
+	)
+	req := requestWithLocationID(t, "house-nick")
+	rr := httptest.NewRecorder()
+
+	handler.GetDashboardByLocation(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (pollen NotFound is non-fatal), got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	var body map[string]map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := len(body["pollen"]); got != 0 {
+		t.Errorf("pollen map should be empty (NotFound), got %d entries", got)
+	}
+	if _, ok := body["weather"]["house-nick"]; !ok {
+		t.Errorf("weather[house-nick] should be present, body: %s", rr.Body.String())
+	}
+	if _, ok := body["pressure"]["house-nick"]; !ok {
+		t.Errorf("pressure[house-nick] should be present, body: %s", rr.Body.String())
+	}
+}
+
+// TestDashboardHandler_GetDashboardByLocation_PollenUnavailable_Fatal
+// is the negative pair to PollenNotFound_PartialData: a non-NotFound
+// pollen error (Unavailable here) is *not* tolerated and should fail the
+// whole request with the appropriate 5xx, even though weather and
+// pressure would otherwise be returnable. This is what protects callers
+// from silently consuming a partial response when an upstream is broken
+// rather than empty.
+func TestDashboardHandler_GetDashboardByLocation_PollenUnavailable_Fatal(t *testing.T) {
+	handler := NewDashboardHandler(
+		&mockWeatherClient{},
+		&errorPollenClient{err: status.Error(codes.Unavailable, "pollen-provider down")},
+	)
+	req := requestWithLocationID(t, "house-nick")
+	rr := httptest.NewRecorder()
+
+	handler.GetDashboardByLocation(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when pollen returns Unavailable, got %d", rr.Code)
+	}
+}
+
+func TestDashboardHandler_GetDashboardByLocation_SlowProviderTimesOut(t *testing.T) {
+	handler := NewDashboardHandler(
+		&slowWeatherClient{delay: 10 * time.Second},
+		&mockPollenClient{},
+	)
+	req := requestWithLocationID(t, "house-nick")
+	rr := httptest.NewRecorder()
+
+	start := time.Now()
+	handler.GetDashboardByLocation(rr, req)
+	elapsed := time.Since(start)
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Errorf("expected status 504, got %d", rr.Code)
+	}
+	if elapsed > shared.RPCClientTimeout+1*time.Second {
+		t.Errorf("expected per-RPC timeout to fire within budget, but took %s", elapsed)
+	}
 }


### PR DESCRIPTION
closes #60 

Adds arrow-key cycling between locations and ↑ to return to all-view, with r re-fetching the current view. Backend gains /v1/dashboard/{locationID} that tolerates per-section NotFound (partial data is OK; 404 only when all sections are absent). CLI uses an LWW merge so out-of-order full/single fetches don't clobber fresher data, and the request timeout is now a default that per-call contexts can override.