### PR TITLE
Correct platform docs for secure-by-default organizations

### DIFF
--- a/docs/platform/00-organization.md
+++ b/docs/platform/00-organization.md
@@ -105,8 +105,55 @@ Two roles are involved, and it's worth knowing which does what:
 | `roles/resourcemanager.projectCreator` | the org | place a project under it |
 | `roles/resourcemanager.projectMover` | the project (or its parent) | move a project out of where it is |
 
-Your Gmail already effectively has the second, as project owner. It needs the first. As
-`nick@yourdomain.com`:
+> Looking for these in the console role picker? They appear as **Project Creator** and **Project
+> Mover** (filter by "Resource Manager"), on the **organization's** IAM page. Don't reach for
+> Owner/Editor — those are far broader roles that happen to contain similar words.
+
+Your Gmail already effectively has the second, as project owner. It needs the first.
+
+### First, unblock the org — it was born restricted
+
+Organizations created on or after **May 3, 2024** are "secure-by-default": Google enforces a
+bundle of org policies at creation, and one of them is `constraints/iam.allowedPolicyMemberDomains`
+(domain-restricted sharing), pre-restricted to your Cloud Identity domain. Until you deal with it,
+every binding below fails with:
+
+```
+IAM policy update failed
+The 'Domain Restricted Sharing' organization policy (constraints/iam.allowedPolicyMemberDomains)
+is enforced. Only principals in allowed domains can be added as principals in the policy.
+```
+
+You can't allow-list the Gmail, either: the constraint's allowed values are Google Workspace /
+Cloud Identity **customer IDs** and **organization principal sets** — managed identity pools. A
+consumer Gmail account belongs to neither. That's by design; excluding unmanaged identities is
+the constraint's entire job.
+
+The fix is **delete → bind → restore**. Enforcement is not retroactive — bindings that exist when
+the policy comes back remain valid — so the org runs unrestricted for minutes, not until Phase 1.
+
+As `nick@yourdomain.com`:
+
+```bash
+# Organization Administrator (auto-granted to the super admin who created the org) can set
+# org IAM, but org *policies* need a separate role. Grant it to yourself:
+gcloud organizations add-iam-policy-binding "$ORG_ID" \
+  --member="user:nick@yourdomain.com" \
+  --role="roles/orgpolicy.policyAdmin"
+
+# Back up Google's policy exactly as created, then delete it:
+gcloud org-policies describe iam.allowedPolicyMemberDomains \
+  --organization="$ORG_ID" > drs-policy-backup.yaml
+gcloud org-policies delete iam.allowedPolicyMemberDomains --organization="$ORG_ID"
+```
+
+> If the self-grant fails with a permission error, your domain user isn't a Cloud Identity super
+> admin yet (the auto-granted Organization Administrator role goes to the super admin who created
+> the org). Fix it at <https://admin.google.com> under **Account → Admin roles → Super Admin**,
+> then retry. Super admin is a Cloud Identity role; Organization Administrator is a GCP IAM role.
+> They're different things and having one doesn't give you the other.
+
+Give the deletion a minute or two to propagate, then make the bindings:
 
 ```bash
 gcloud organizations add-iam-policy-binding "$ORG_ID" \
@@ -126,10 +173,22 @@ gcloud organizations add-iam-policy-binding "$ORG_ID" \
   --role="roles/resourcemanager.organizationAdmin"
 ```
 
-> If that last command fails with a permission error, your domain user isn't a Cloud Identity super
-> admin yet. Fix it at <https://admin.google.com> under **Account → Admin roles → Super Admin**,
-> then retry. Super admin is a Cloud Identity role; Organization Administrator is a GCP IAM role.
-> They're different things and having one doesn't give you the other.
+Then restore the domain restriction **in the same sitting**:
+
+```bash
+gcloud org-policies set-policy drs-policy-backup.yaml
+
+# Confirm it's back, and the Gmail's bindings survived:
+gcloud org-policies describe iam.allowedPolicyMemberDomains --organization="$ORG_ID"
+gcloud organizations get-iam-policy "$ORG_ID" \
+  --flatten="bindings[].members" --filter="bindings.members:fang.nicholas" \
+  --format="table(bindings.role)"
+```
+
+> If `set-policy` rejects the backup file, strip any `etag:` and `updateTime:` lines and retry.
+> Leave the other secure-by-default policies (`iam.disableServiceAccountKeyCreation` and friends)
+> alone — deploys authenticate with Workload Identity Federation, so nothing needs service account
+> keys, and Phase 1 imports these policies into Terraform.
 
 ## 6. Create the folders
 
@@ -185,9 +244,8 @@ gcloud projects list --format="table(projectId, parent.type, parent.id)"
 The moment a project lands in a folder, it inherits everything above it. That's the point, and it's
 also how people break production during a migration.
 
-**Do not enable domain-restricted sharing yet.** The constraint
-`constraints/iam.allowedPolicyMemberDomains` blocks `allUsers` and `allAuthenticatedUsers` from IAM
-policies. Your dashboard API depends on exactly that:
+Domain-restricted sharing (`constraints/iam.allowedPolicyMemberDomains`) is enforced again — §5
+restored it after the Gmail bindings. Your dashboard API has a binding this constraint forbids:
 
 ```hcl
 # infra/modules/cloud-run-aggregator/main.tf:55-60
@@ -197,9 +255,16 @@ resource "google_cloud_run_v2_service_iam_member" "public_invoker" {
 }
 ```
 
-Turn it on org-wide and your public API stops being public, and the next `terraform apply` fails
-trying to restore the binding. Phase 1 sets up org policies with the exemptions this needs. Until
-then, add no constraints.
+Two facts about how the constraint behaves keep the move safe, and both matter:
+
+- **Enforcement is not retroactive.** The existing `allUsers` binding survives the project move
+  untouched — moving a project changes its parent, not its IAM policy. The public API keeps
+  answering.
+- **New policy writes are what's blocked.** The next `terraform apply` that needs to create or
+  recreate that binding fails until Phase 1 lands the folder exemptions.
+
+So between now and Phase 1: move projects freely, but don't change staging or prod infrastructure
+that touches the public invoker, and don't run an apply that would recreate it.
 
 ## 8. Create the groups
 
@@ -293,6 +358,17 @@ gcloud projects list --format="table(projectId, parent.type, parent.id)"
 curl -sS -o /dev/null -w '%{http_code}\n' https://<your-staging-api-domain>/api/v1/dashboard
 ```
 Expect `200`. If you get `403`, an inherited policy is blocking `allUsers` — see section 7.
+
+```bash
+# 5. Domain restriction is back on, and the Gmail kept its org roles
+gcloud org-policies describe iam.allowedPolicyMemberDomains --organization="$ORG_ID"
+gcloud organizations get-iam-policy "$ORG_ID" \
+  --flatten="bindings[].members" --filter="bindings.members:fang.nicholas" \
+  --format="table(bindings.role)"
+```
+The policy exists, and the roles list includes `projectCreator` and `projectMover`. If you want
+proof the restriction is really enforcing, try adding any Gmail binding — it should fail with the
+same Domain Restricted Sharing error §5 started with.
 
 Also worth confirming your existing deploys still work, since the projects moved underneath them:
 re-run one GitHub Actions deploy workflow and check it completes. Workload Identity Federation

--- a/docs/platform/01-bootstrap-and-platform.md
+++ b/docs/platform/01-bootstrap-and-platform.md
@@ -325,13 +325,26 @@ resource "google_org_policy_policy" "disable_sa_keys" {
 }
 ```
 
-> **Optional, and verify before you commit to it.** `constraints/iam.allowedPolicyMemberDomains`
-> restricts IAM members to your Cloud Identity customer ID. It's a genuinely good control — it
-> stops anyone binding a role to an arbitrary Gmail address. But it also blocks `allUsers`, and
-> `infra/modules/cloud-run-aggregator/main.tf:55-60` binds `roles/run.invoker` to `allUsers` to make
-> the dashboard API public.
+> **Secure-by-default orgs already have this policy.** Organizations created on or after May 3,
+> 2024 get `iam.disableServiceAccountKeyCreation` (and several other policies) enforced by Google
+> at creation. Terraform can't create what already exists — the first apply fails with "already
+> exists". Import it first:
 >
-> If you want it, you enforce at the org and relax it on the folders that host public services:
+> ```bash
+> terraform import google_org_policy_policy.disable_sa_keys \
+>   "organizations/${ORG_ID}/policies/iam.disableServiceAccountKeyCreation"
+> ```
+
+> **Already enforced — your job here is exemptions, not adoption.** On a secure-by-default org,
+> `constraints/iam.allowedPolicyMemberDomains` has been on since the org was created (Phase 0 §5
+> dropped it briefly to bind your Gmail, then restored it). It's a genuinely good control — it
+> stops anyone binding a role to an arbitrary Gmail address. But it also blocks new `allUsers`
+> bindings, and `infra/modules/cloud-run-aggregator/main.tf:55-60` binds `roles/run.invoker` to
+> `allUsers` to make the dashboard API public. The existing binding survives (enforcement is not
+> retroactive), but Terraform can't recreate it until the folder exemptions below exist.
+>
+> Keep enforcing at the org — importing the policy that's already there — and relax it on the
+> folders that host public services:
 >
 > ```hcl
 > resource "google_org_policy_policy" "domain_restricted_sharing" {
@@ -357,6 +370,19 @@ resource "google_org_policy_policy" "disable_sa_keys" {
 >   }
 > }
 > ```
+>
+> The org-level policy already exists, so import it — only the folder exemptions are genuinely
+> new resources:
+>
+> ```bash
+> terraform import google_org_policy_policy.domain_restricted_sharing \
+>   "organizations/${ORG_ID}/policies/iam.allowedPolicyMemberDomains"
+> ```
+>
+> After the import, check `terraform plan` before applying: if Google's original policy expresses
+> the restriction differently than the HCL above (for example an organization principal set
+> instead of `is:C0xxxxxxx`), align the HCL to what's actually there rather than letting Terraform
+> rewrite the policy.
 >
 > Apply it, then immediately `curl` your staging API and re-run `terraform plan` in `infra/staging`.
 > If the plan wants to recreate `public_invoker`, the exemption isn't taking effect. Roll the policy


### PR DESCRIPTION
## Summary

Phase 0 of the platform tutorial broke at step 5 with a Domain Restricted Sharing error. Root cause (verified against Google's Resource Manager docs): **orgs created on or after May 3, 2024 are "secure-by-default"** — Google enforces a bundle of org policies at creation, including `constraints/iam.allowedPolicyMemberDomains`. The tutorial assumed a clean pre-2024 org.

Verified along the way:
- The constraint's allowed values are customer IDs / org principal sets only — a consumer Gmail can never be allow-listed, so the binding requires temporarily removing the policy.
- Enforcement is **not retroactive** — existing bindings (including the public API's `allUsers` invoker) survive; only new policy writes are blocked. §7 previously claimed the opposite.
- Step 5's role prescriptions were correct as written.

## Changes

- **00-organization.md §5**: delete → bind → restore sequence (back up Google's policy with `org-policies describe`, delete, bind the Gmail, restore from the backup in the same sitting), console role-naming note, super-admin troubleshooting moved to the first command that can hit it.
- **00-organization.md §7**: rewritten — the constraint is enforced again after §5; project moves are safe; the next `terraform apply` touching the public invoker is what breaks until Phase 1's folder exemptions.
- **00-organization.md verification gate**: new check #5 — restriction restored, Gmail bindings intact.
- **01-bootstrap-and-platform.md §3.2**: both `iam.disableServiceAccountKeyCreation` and the DRS policy already exist on secure-by-default orgs — `terraform import` them instead of creating; check the plan for value-format drift before applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)