### PR TITLE
Document group settings for Phase 0 security groups

### DIFF
--- a/docs/platform/00-organization.md
+++ b/docs/platform/00-organization.md
@@ -286,6 +286,21 @@ At <https://admin.google.com> → **Directory → Groups**, create four:
 | `gcp-staging-viewers@yourdomain.com` | stakeholders who need to see staging | read-only on `folders/staging` |
 | `gcp-prod-oncall@yourdomain.com` | whoever can touch prod | scoped access to `folders/prod` |
 
+The create-group wizard's second page ("Group settings") defaults to mailing-list behavior. These
+groups grant cloud permissions to their members, so the deciding rule is: **membership must never
+be self-service** — joining `gcp-platform-admins` would mean granting yourself org-level admin.
+For all four groups:
+
+- **Access type: Restricted** — not the default "Public", which lets anyone in the org join
+  themselves.
+- **Who can join the group: Only invited users** — the setting that actually matters; membership
+  changes stay a deliberate admin action.
+- **Allow external members: both boxes unchecked** — domain-restricted sharing validates the
+  *group's* domain in IAM bindings, not its members', so an external member would ride the
+  group's bindings past that control.
+- The access-settings grid (who can contact owners / view conversations / post) governs the group
+  as a mailing list — irrelevant here; the Restricted presets are fine.
+
 Add `nick@yourdomain.com` to `gcp-platform-admins` and leave the rest empty. They exist so Phase 3
 can bind roles to them — an empty group with a role attached is fine and is exactly how you want
 this to work. Adding a stakeholder later becomes a click in the admin console, not a Terraform run.

--- a/docs/platform/00-organization.md
+++ b/docs/platform/00-organization.md
@@ -334,14 +334,44 @@ remove it until you've verified the break-glass account works.
 
 ## 10. Request project quota
 
-The ephemeral environment factory in Phase 4 creates a project per environment. Default quota won't
-support that.
+The ephemeral environment factory in Phase 4 creates a project per environment — personal-account
+project quotas wouldn't support that, but organizations start much higher.
 
-Console → **IAM & Admin → Quotas & System Limits**, filter for the Cloud Resource Manager project
-creation limit, and request an increase. Ask for something defensible — 50 is plenty for per-branch
-environments with a reaper cleaning up.
+Check what the org already has before requesting anything — organizations start with a per-org
+cap that may already be enough:
 
-Approval takes a few days, so file it now and continue. Phases 1 through 3 don't depend on it.
+```bash
+gcloud beta quotas info list \
+  --organization="$ORG_ID" \
+  --service=cloudresourcemanager.googleapis.com
+```
+
+(If it complains the Cloud Quotas API isn't enabled, enable `cloudquotas.googleapis.com` on the
+project the error names and retry.) In the `projects_count` entry, `dimensionsInfos` holds the
+current limit and `quotaId: ProjectsPerOrg` identifies the quota. **A limit of 50 is plenty** for
+per-branch environments with a reaper cleaning up — if you see that, this step is done.
+
+If yours is lower, request an increase from the CLI:
+
+```bash
+gcloud beta quotas preferences create \
+  --organization="$ORG_ID" \
+  --service=cloudresourcemanager.googleapis.com \
+  --quota-id=ProjectsPerOrg \
+  --preferred-value=50 \
+  --email=nick@yourdomain.com
+```
+
+or in the console: **IAM & Admin → Quotas & System Limits**, select the **organization** in the
+resource picker (the cap lives on the org — with a project selected it isn't listed), filter with
+property **Metric** = `cloudresourcemanager.googleapis.com/projects_count`, then **Edit quota**.
+
+Project creation checks both your user quota and the org quota and succeeds if *either* has
+capacity — the org-level number is the one that matters here, since the Phase 4 factory creates
+projects as a service account under the org.
+
+If you did file a request, approval takes a few days — continue without waiting. Phases 1 through
+3 don't depend on it.
 
 ## 11. Move billing under the org (optional, do it now if at all)
 


### PR DESCRIPTION
## Summary

Third gap found while walking Phase 0 for real: §8 says to create the four IAM groups but not what to pick on the wizard's "Group settings" page, whose defaults (Public, anyone-can-join) amount to self-service privilege escalation for permission-bearing groups.

Adds the settings and the reasoning: **Restricted** access type, **only invited users** can join, **no external members** (domain-restricted sharing checks the group's domain, not its members'), and a note that the mailing-list access grid is irrelevant for IAM use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)